### PR TITLE
Normalize mousewheel scroll across browsers.

### DIFF
--- a/src/ng-scrollbar.js
+++ b/src/ng-scrollbar.js
@@ -83,15 +83,22 @@ angular.module('ngScrollbar', []).directive('ngScrollbar', [
 
         var wheelHandler = function(event) {
 
-          var wheelDivider = 20; // so it can be changed easily
+          var wheelSpeed = 40;
 
-          var deltaY = event.wheelDeltaY !== undefined ?
-            event.wheelDeltaY / wheelDivider :
-              event.wheelDelta !== undefined ?
-            event.wheelDelta / wheelDivider :
-            -event.detail * (wheelDivider / 10);
+          // Mousewheel speed normalization approach adopted from
+          // http://stackoverflow.com/a/13650579/1427418
+          var o = event, d = o.detail, w = o.wheelDelta, n = 225, n1 = n-1;
 
-          dragger.top = Math.max(0, Math.min(parseInt(page.height, 10) - parseInt(dragger.height, 10), parseInt(dragger.top, 10) - deltaY));
+          // Normalize delta
+          d = d ? w && (f = w/d) ? d/f : -d/1.35 : w/120;
+          // Quadratic scale if |d| > 1
+          d = d < 1 ? d < -1 ? (-Math.pow(d, 2) - n1) / n : d : (Math.pow(d, 2) + n1) / n;
+          // Delta *should* not be greater than 2...
+          event.delta = Math.min(Math.max(d / 2, -1), 1);
+
+          event.delta = event.delta * wheelSpeed;
+
+          dragger.top = Math.max(0, Math.min(parseInt(page.height, 10) - parseInt(dragger.height, 10), parseInt(dragger.top, 10) - event.delta));
           redraw();
 
           if (!!event.preventDefault) {


### PR DESCRIPTION
Per discussion in #33 we need to normalize mousewheel scroll across browsers.

I have adopted an approach discussed here:
http://stackoverflow.com/a/13650579/1427418

Tested on IE 11, Firefox 36 (Win 7 and OS X), Chrome 41 (Win and OS X), Safari.

Perhaps if I have more time I can open another PR to externalize `wheelSpeed` as a configurable option, unless you beat me to it :smile: 
