### PR TITLE
Removing adjustment for parentOffsetTop which can cause issues with both the scollbar container size and the calculated scroll length

### DIFF
--- a/src/ng-scrollbar.js
+++ b/src/ng-scrollbar.js
@@ -172,11 +172,7 @@ angular.module('ngScrollbar', []).directive('ngScrollbar', [
           thumbLine = angular.element(thumb.children()[0]);
           track = angular.element(angular.element(tools.children()[0]).children()[1]);
 
-          // Check if scroll bar is needed
-          page.height = element[0].offsetHeight - parentOffsetTop;
-          if (page.height < 0) {
-            page.height = element[0].offsetHeight;
-          }
+          page.height = element[0].offsetHeight;
           page.scrollHeight = transculdedContainer[0].scrollHeight;
 
           if (page.height < page.scrollHeight) {

--- a/src/ng-scrollbar.js
+++ b/src/ng-scrollbar.js
@@ -161,9 +161,6 @@ angular.module('ngScrollbar', []).directive('ngScrollbar', [
 
         var buildScrollbar = function (rollToBottom) {
 
-          // Getting top position of a parent element to place scroll correctly
-          var parentOffsetTop = element[0].parentElement.offsetTop;
-
           rollToBottom = flags.bottom || rollToBottom;
           mainElm = angular.element(element.children()[0]);
           transculdedContainer = angular.element(mainElm.children()[0]);


### PR DESCRIPTION
* Several of us were having issues with calculation of ```page.height``` as noted here: https://github.com/asafdav/ng-scrollbar/issues/35
* The most serious issues I came across were in cases where multiple ng-scrollbar instances were stacked vertically, leading to containers with unpredictable sizes and scrollbars that track far beyond the content of the container and getting stuck
* While Chesterton's fence would have me understand the reasoning behind the ```parentOffsetTop``` adjustment before removing it, I haven't been able to find a case where it is needed and the current unexpected behavior is a major pain point for certain applications
*  Simplifying the calculation to ```page.height = element[0].offsetHeight;``` resolves the issues nicely and restores expected behavior for what has otherwise been a very helpful scrollbar module 